### PR TITLE
~Переработка магазинного питания

### DIFF
--- a/trunk/xray/xr_3da/xrGame/Weapon.cpp
+++ b/trunk/xray/xr_3da/xrGame/Weapon.cpp
@@ -499,7 +499,7 @@ BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
 	SetNextState(E->wpn_state);
 	//
 	bMisfire = E->bMisfire;
-	Msg("CWeapon::net_Spawn: weapon [%s] with m_ammoType [%d], ammo [%s]", Name_script(), m_ammoType, *m_ammoTypes[m_ammoType]);
+	//Msg("CWeapon::net_Spawn: weapon [%s] with m_ammoType [%d], ammo [%s]", Name_script(), m_ammoType, *m_ammoTypes[m_ammoType]);
 	m_DefaultCartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));
 	if (iAmmoElapsed)
 	{
@@ -996,7 +996,7 @@ int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 		if (g_actor->m_inventory != m_pCurrentInventory || !psActorFlags.test(AF_AMMO_FROM_BELT)) //очень некрасивый костыль!
 		return l_count + iAmmoCurrent;
 
-	Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, *m_ammoTypes[m_ammoType], this->Name_script());
+	//Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, *m_ammoTypes[m_ammoType], this->Name_script());
 
 	m_dwAmmoCurrentCalcFrame = Device.dwFrame;
 	iAmmoCurrent = 0;
@@ -1036,7 +1036,7 @@ int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 
 		iAmmoCurrent += inventory_owner().ammo_in_box_to_spawn();
 
-		Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, l_ammoType, this->Name_script());
+		//Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, l_ammoType, this->Name_script());
 	}
 	return l_count + iAmmoCurrent;
 }

--- a/trunk/xray/xr_3da/xrGame/Weapon.cpp
+++ b/trunk/xray/xr_3da/xrGame/Weapon.cpp
@@ -499,37 +499,13 @@ BOOL CWeapon::net_Spawn(CSE_Abstract* DC)
 	SetNextState(E->wpn_state);
 	//
 	bMisfire = E->bMisfire;
-	//Msg("CWeapon::net_Spawn: weapon [%s] with m_ammoType [%d], ammo [%s]", Name_script(), m_ammoType, *m_ammoTypes[m_ammoType]);
+	Msg("CWeapon::net_Spawn: weapon [%s] with m_ammoType [%d], ammo [%s]", Name_script(), m_ammoType, *m_ammoTypes[m_ammoType]);
 	m_DefaultCartridge.Load(*m_ammoTypes[m_ammoType], u8(m_ammoType));
-	/*if (iAmmoElapsed)
+	if (iAmmoElapsed)
 	{
 		m_fCurrentCartirdgeDisp = m_DefaultCartridge.m_kDisp;
 		for (int i = 0; i < iAmmoElapsed; ++i)
 			m_magazine.push_back(m_DefaultCartridge);
-	}*/
-	if (iAmmoElapsed)
-	{
-		m_magazine.clear();
-		m_fCurrentCartirdgeDisp = m_DefaultCartridge.m_kDisp;
-
-		if (E->m_AmmoIDs.empty())
-		{
-			//Msg("CWeapon::net_Spawn weapon [%s] with m_ammoType [%d], ammo [%s] - E->m_AmmoIDs.empty()", Name_script(), m_ammoType, *m_ammoTypes[m_ammoType]);
-			for (int i = 0; i < iAmmoElapsed; ++i)
-				m_magazine.push_back(m_DefaultCartridge);
-		}
-		else
-		{
-			//Msg("CWeapon::net_Spawn weapon [%s] with m_ammoType [%d], ammo [%s]", Name_script(), m_ammoType, *m_ammoTypes[m_ammoType]);
-			std::for_each(E->m_AmmoIDs.begin(), E->m_AmmoIDs.end(), [&](u8 at)
-			{
-				if (at > m_ammoTypes.size())
-					at = 0;
-				m_DefaultCartridge.Load(*m_ammoTypes[at], at);
-				m_magazine.push_back(m_DefaultCartridge);
-				//Msg("CWeapon::net_Spawn weapon [%s] loaded with m_ammoType [%d], ammo [%s] - has E->m_AmmoIDs", Name_script(), at, *m_ammoTypes[at]);
-			});
-		}
 	}
 
 	UpdateAddonsVisibility();
@@ -579,14 +555,6 @@ void CWeapon::net_Export(NET_Packet& P)
 	P.w_u8((u8)m_bZoomMode);
 	//
 	P.w_u8((u8)bMisfire);
-	//
-	P.w_u8(u8(m_magazine.size()));
-	for (u32 i = 0; i<m_magazine.size(); i++)
-	{
-		CCartridge& l_cartridge = *(m_magazine.begin() + i);
-		P.w_u8(l_cartridge.m_LocalAmmoType);
-	}
-	//
 }
 
 void CWeapon::net_Import(NET_Packet& P)
@@ -615,11 +583,6 @@ void CWeapon::net_Import(NET_Packet& P)
 	P.r_u8((u8)Zoom);
 	//
 	bMisfire = !!(P.r_u8() & 0x1);
-	//
-	u8 AmmoCount, LocalAmmoType;
-	P.r_u8(AmmoCount);
-	P.r_u8(LocalAmmoType);
-	//
 
 	if (H_Parent() && H_Parent()->Remote())
 	{
@@ -642,19 +605,6 @@ void CWeapon::net_Import(NET_Packet& P)
 		{
 			m_ammoType = ammoType;
 			SetAmmoElapsed((ammo_elapsed));
-			//
-			for (u32 i = 0; i<AmmoCount; i++)
-			{
-				if (i >= m_magazine.size()) continue;
-				CCartridge& l_cartridge = *(m_magazine.begin() + i);
-				if (LocalAmmoType == l_cartridge.m_LocalAmmoType) continue;
-#ifdef DEBUG
-				Msg("! %s reload to %s", *l_cartridge.m_ammoSect, *(m_ammoTypes[LocalAmmoType]));
-#endif
-				l_cartridge.Load(*(m_ammoTypes[LocalAmmoType]), LocalAmmoType);
-				//		m_fCurrentCartirdgeDisp = m_DefaultCartridge.m_kDisp;		
-			}
-			//
 		}
 	}break;
 	}
@@ -1046,7 +996,7 @@ int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 		if (g_actor->m_inventory != m_pCurrentInventory || !psActorFlags.test(AF_AMMO_FROM_BELT)) //очень некрасивый костыль!
 		return l_count + iAmmoCurrent;
 
-	//Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, *m_ammoTypes[m_ammoType], this->Name_script());
+	Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, *m_ammoTypes[m_ammoType], this->Name_script());
 
 	m_dwAmmoCurrentCalcFrame = Device.dwFrame;
 	iAmmoCurrent = 0;
@@ -1086,7 +1036,7 @@ int CWeapon::GetAmmoCurrent(bool use_item_to_spawn) const
 
 		iAmmoCurrent += inventory_owner().ammo_in_box_to_spawn();
 
-		//Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, l_ammoType, this->Name_script());
+		Msg("[%s] get ammo current [%d]:[%s] weapon [%s] ", m_pCurrentInventory->GetOwner()->Name(), l_count + iAmmoCurrent, l_ammoType, this->Name_script());
 	}
 	return l_count + iAmmoCurrent;
 }

--- a/trunk/xray/xr_3da/xrGame/WeaponMagazined.cpp
+++ b/trunk/xray/xr_3da/xrGame/WeaponMagazined.cpp
@@ -302,7 +302,7 @@ void CWeaponMagazined::UnloadAmmo(int unload_count, bool spawn_ammo, bool detach
 	{
 		int chamber_ammo = HasChamber() ? 1 : 0;	//учтём дополнительный патрон в патроннике
 
-		if (iAmmoElapsed <= chamber_ammo && IsMagazineAttached() && ParentIsActor())	//spawn mag empty - for actor only
+		if (iAmmoElapsed <= chamber_ammo && IsMagazineAttached() && spawn_ammo)	//spawn mag empty
 		{
 			LPCSTR empty_sect = pSettings->r_string(*m_ammoTypes[m_LastLoadedMagType], "empty_box");
 			SpawnAmmo(0, empty_sect);

--- a/trunk/xray/xr_3da/xrGame/WeaponMagazined.cpp
+++ b/trunk/xray/xr_3da/xrGame/WeaponMagazined.cpp
@@ -50,7 +50,7 @@ CWeaponMagazined::CWeaponMagazined(LPCSTR name, ESoundTypes eSoundType) : CWeapo
 	//
 	m_bHasChamber				= true;
 	m_LastLoadedMagType			= 0;
-	m_bIsMagazineAttached		= true;
+	//m_bIsMagazineAttached		= true;
 }
 
 CWeaponMagazined::~CWeaponMagazined()
@@ -302,14 +302,15 @@ void CWeaponMagazined::UnloadAmmo(int unload_count, bool spawn_ammo, bool detach
 	{
 		int chamber_ammo = HasChamber() ? 1 : 0;	//учтём дополнительный патрон в патроннике
 
-		if (iAmmoElapsed <= chamber_ammo && m_bIsMagazineAttached)	//spawn mag empty
+		if (iAmmoElapsed <= chamber_ammo && IsMagazineAttached() && ParentIsActor())	//spawn mag empty - for actor only
 		{
 			LPCSTR empty_sect = pSettings->r_string(*m_ammoTypes[m_LastLoadedMagType], "empty_box");
 			SpawnAmmo(0, empty_sect);
 		}
 
 		iMagazineSize = 1;
-		m_bIsMagazineAttached = false;
+		//m_bIsMagazineAttached = false;
+		m_flagsAddOnState &= ~CSE_ALifeItemWeapon::eWeaponAddonMagazine;
 	}
 
 	xr_map<LPCSTR, u16> l_ammo;
@@ -356,7 +357,7 @@ void CWeaponMagazined::UnloadMagazine(bool spawn_ammo)
 	UnloadAmmo(iAmmoElapsed - chamber_ammo, spawn_ammo, HasDetachableMagazine());
 }
 
-bool CWeaponMagazined::HasDetachableMagazine()
+bool CWeaponMagazined::HasDetachableMagazine() const
 {
 	for (u32 i = 0; i < m_ammoTypes.size(); ++i)
 	{
@@ -366,6 +367,12 @@ bool CWeaponMagazined::HasDetachableMagazine()
 	}
 
 	return false;
+}
+
+bool CWeaponMagazined::IsMagazineAttached()
+{
+	//return m_bIsMagazineAttached;
+	return (0 != (m_flagsAddOnState&CSE_ALifeItemWeapon::eWeaponAddonMagazine)) && HasDetachableMagazine();
 }
 
 void CWeaponMagazined::HandleCartridgeInChamber()
@@ -459,7 +466,8 @@ void CWeaponMagazined::ReloadMagazine()
 		int chamber_ammo = HasChamber() ? 1 : 0;	//учтём дополнительный патрон в патроннике
 		iMagazineSize = m_pAmmo->m_boxSize + chamber_ammo; 
 		m_LastLoadedMagType = m_ammoType;
-		m_bIsMagazineAttached = true;
+		//m_bIsMagazineAttached = true;
+		m_flagsAddOnState |= CSE_ALifeItemWeapon::eWeaponAddonMagazine;
 	}
 
 	VERIFY((u32)iAmmoElapsed == m_magazine.size());
@@ -1403,8 +1411,8 @@ void CWeaponMagazined::save(NET_Packet &output_packet)
 	save_data(m_iShotNum, output_packet);
 	save_data(m_iCurFireMode, output_packet);
 	//
-	save_data(m_LastLoadedMagType, output_packet);
-	save_data(m_bIsMagazineAttached, output_packet);
+	//save_data(m_LastLoadedMagType, output_packet);
+	//save_data(m_bIsMagazineAttached, output_packet);
 }
 
 void CWeaponMagazined::load(IReader &input_packet)
@@ -1414,8 +1422,8 @@ void CWeaponMagazined::load(IReader &input_packet)
 	load_data(m_iShotNum, input_packet);
 	load_data(m_iCurFireMode, input_packet);
 	//
-	load_data(m_LastLoadedMagType, input_packet);
-	load_data(m_bIsMagazineAttached, input_packet);
+	//load_data(m_LastLoadedMagType, input_packet);
+	//load_data(m_bIsMagazineAttached, input_packet);
 }
 
 BOOL CWeaponMagazined::net_Spawn(CSE_Abstract* DC)
@@ -1424,24 +1432,21 @@ BOOL CWeaponMagazined::net_Spawn(CSE_Abstract* DC)
 	CSE_ALifeItemWeaponMagazined* const wpn = smart_cast<CSE_ALifeItemWeaponMagazined*>(DC);
 	m_iCurFireMode = wpn->m_u8CurFireMode;
 	SetQueueSize(GetCurrentFireMode());
-	//если оружие не заряжено то это не нужно делать
-	if (iAmmoElapsed && wpn->m_AmmoIDs.size()>0)
+	//multitype ammo loading
+	xr_vector<u8> ammo_ids = wpn->m_AmmoIDs;
+
+	for (u32 i = 0; i < ammo_ids.size(); i++)
 	{
-		m_magazine.clear();
-		Msg("CWeaponMagazined::net_Spawn weapon [%s] with m_ammoType [%d], ammo [%s]", Name_script(), m_ammoType, *m_ammoTypes[m_ammoType]);
-		std::for_each(wpn->m_AmmoIDs.begin(), wpn->m_AmmoIDs.end(), [&](u8 at)
-		{
-			if (at > m_ammoTypes.size())
-				at = 0;
-			CCartridge l_cartridge;
-			l_cartridge.Load(*m_ammoTypes[at], at);
-			m_magazine.push_back(l_cartridge);
-		});
+		u8 LocalAmmoType = ammo_ids[i];
+		if (i >= m_magazine.size()) continue;
+		CCartridge& l_cartridge = *(m_magazine.begin() + i);
+		if (LocalAmmoType == l_cartridge.m_LocalAmmoType) continue;
+		l_cartridge.Load(*m_ammoTypes[LocalAmmoType], LocalAmmoType);
 	}
-	//если номер типа магазина некорректен (это бывает при спавне разряженного оружия) - не будем присваивать значение, пусть будет тип по умолчанию
-	if (wpn->m_LastLoadedMagType < m_ammoTypes.size())
-		m_LastLoadedMagType = wpn->m_LastLoadedMagType;
-	m_bIsMagazineAttached = wpn->m_bIsMagazineAttached;
+	//
+	if (IsMagazineAttached())
+		m_LastLoadedMagType = m_ammoType;
+	//m_bIsMagazineAttached = wpn->m_bIsMagazineAttached;
 	//
 	return bRes;
 }
@@ -1459,8 +1464,7 @@ void CWeaponMagazined::net_Export(NET_Packet& P)
 		P.w_u8(l_cartridge.m_LocalAmmoType);
 	}
 	//
-	P.w_u8(u8(m_LastLoadedMagType));
-	P.w_u8(m_bIsMagazineAttached ? 1 : 0);
+	//P.w_u8(m_bIsMagazineAttached ? 1 : 0);
 }
 
 void CWeaponMagazined::net_Import(NET_Packet& P)
@@ -1487,8 +1491,7 @@ void CWeaponMagazined::net_Import(NET_Packet& P)
 		//		m_fCurrentCartirdgeDisp = m_DefaultCartridge.m_kDisp;		
 	}
 	//
-	m_LastLoadedMagType = P.r_u8();
-	m_bIsMagazineAttached = !!(P.r_u8() & 0x1);
+	//m_bIsMagazineAttached = !!(P.r_u8() & 0x1);
 }
 #include "string_table.h"
 #include "ui/UIMainIngameWnd.h"

--- a/trunk/xray/xr_3da/xrGame/WeaponMagazined.h
+++ b/trunk/xray/xr_3da/xrGame/WeaponMagazined.h
@@ -188,7 +188,7 @@ protected:
 	//последний заряженный тип магазина
 	u32				m_LastLoadedMagType;
 	//присоединён ли магазин
-	bool			m_bIsMagazineAttached;
+	//bool			m_bIsMagazineAttached;
 
 	//переменная блокирует использование
 	//только разных типов патронов
@@ -207,8 +207,8 @@ public:
 	virtual LPCSTR	GetCurrentFireModeStr	() {return m_sCurFireMode;};
 
 	//оружие использует отъёмный магазин
-	virtual bool	HasDetachableMagazine	();
-	virtual bool	IsMagazineAttached		() { return m_bIsMagazineAttached; };
+	virtual bool	HasDetachableMagazine	() const;
+	virtual bool	IsMagazineAttached		();
 	//у оружия есть патронник
 	virtual bool	HasChamber				() { return /*ParentIsActor() &&*/ m_bHasChamber; };
 

--- a/trunk/xray/xr_3da/xrGame/WeaponShotgun.cpp
+++ b/trunk/xray/xr_3da/xrGame/WeaponShotgun.cpp
@@ -454,12 +454,51 @@ u8 CWeaponShotgun::AddCartridge		(u8 cnt)
 	return cnt;
 }
 
+/*BOOL	CWeaponShotgun::net_Spawn(CSE_Abstract* DC)
+{
+	BOOL bRes = inherited::net_Spawn(DC);
+
+	CSE_ALifeItemWeaponShotGun* _dc = smart_cast<CSE_ALifeItemWeaponShotGun*>(DC);
+	xr_vector<u8> ammo_ids = _dc->m_AmmoIDs;
+
+	for (u32 i = 0; i < ammo_ids.size(); i++)
+	{
+		u8 LocalAmmoType = ammo_ids[i];
+		if (i >= m_magazine.size()) continue;
+		CCartridge& l_cartridge = *(m_magazine.begin() + i);
+		if (LocalAmmoType == l_cartridge.m_LocalAmmoType) continue;
+		l_cartridge.Load(*m_ammoTypes[LocalAmmoType], LocalAmmoType);
+	}
+
+	return bRes;
+}
+
 void	CWeaponShotgun::net_Export	(NET_Packet& P)
 {
 	inherited::net_Export(P);	
+
+	P.w_u8(u8(m_magazine.size()));
+	for (u32 i = 0; i<m_magazine.size(); i++)
+	{
+		CCartridge& l_cartridge = *(m_magazine.begin() + i);
+		P.w_u8(l_cartridge.m_LocalAmmoType);
+	}
 }
 
 void	CWeaponShotgun::net_Import	(NET_Packet& P)
 {
 	inherited::net_Import(P);	
-}
+
+	u8 AmmoCount = P.r_u8();
+	for (u32 i = 0; i<AmmoCount; i++)
+	{
+		u8 LocalAmmoType = P.r_u8();
+		if (i >= m_magazine.size()) continue;
+		CCartridge& l_cartridge = *(m_magazine.begin() + i);
+		if (LocalAmmoType == l_cartridge.m_LocalAmmoType) continue;
+#ifdef DEBUG
+		Msg("! %s reload to %s", *l_cartridge.m_ammoSect, *(m_ammoTypes[LocalAmmoType]));
+#endif
+		l_cartridge.Load(*(m_ammoTypes[LocalAmmoType]), LocalAmmoType);
+	}
+}*/

--- a/trunk/xray/xr_3da/xrGame/WeaponShotgun.h
+++ b/trunk/xray/xr_3da/xrGame/WeaponShotgun.h
@@ -10,11 +10,11 @@ public:
 	CWeaponShotgun(void);
 	virtual ~CWeaponShotgun(void);
 
-	virtual void	Load			(LPCSTR section);
-	
+	virtual void	Load				(LPCSTR section);
+	//virtual BOOL	net_Spawn			(CSE_Abstract* DC);
 	virtual void	net_Destroy			();
-	virtual void	net_Export			(NET_Packet& P);
-	virtual void	net_Import			(NET_Packet& P);
+	//virtual void	net_Export			(NET_Packet& P);
+	//virtual void	net_Import			(NET_Packet& P);
 
 	virtual void	Reload				();
 	virtual void	Fire2Start			();

--- a/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.cpp
+++ b/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.cpp
@@ -590,8 +590,7 @@ CSE_ALifeItemWeaponMagazined::CSE_ALifeItemWeaponMagazined	(LPCSTR caSection) : 
 	//
 	m_AmmoIDs.clear();
 	//
-	m_LastLoadedMagType = 0;
-	m_bIsMagazineAttached = true;
+	//m_bIsMagazineAttached = true;
 }
 
 CSE_ALifeItemWeaponMagazined::~CSE_ALifeItemWeaponMagazined	()
@@ -611,8 +610,7 @@ void CSE_ALifeItemWeaponMagazined::UPDATE_Read		(NET_Packet& P)
 		m_AmmoIDs.push_back(P.r_u8());
 	}
 	//
-	m_LastLoadedMagType = P.r_u8();
-	m_bIsMagazineAttached	= !!(P.r_u8() & 0x1);
+	//m_bIsMagazineAttached	= !!(P.r_u8() & 0x1);
 }
 void CSE_ALifeItemWeaponMagazined::UPDATE_Write	(NET_Packet& P)
 {
@@ -626,8 +624,7 @@ void CSE_ALifeItemWeaponMagazined::UPDATE_Write	(NET_Packet& P)
 		P.w_u8(u8(m_AmmoIDs[i]));
 	}
 	//
-	P.w_u8(m_LastLoadedMagType);
-	P.w_u8(m_bIsMagazineAttached ? 1 : 0);
+	//P.w_u8(m_bIsMagazineAttached ? 1 : 0);
 }
 void CSE_ALifeItemWeaponMagazined::STATE_Read		(NET_Packet& P, u16 size)
 {

--- a/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.cpp
+++ b/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.cpp
@@ -383,8 +383,6 @@ CSE_ALifeItemWeapon::CSE_ALifeItemWeapon	(LPCSTR caSection) : CSE_ALifeItem(caSe
 	m_ef_weapon_type			= READ_IF_EXISTS(pSettings,r_u32,caSection,"ef_weapon_type",u32(-1));
 	//
 	bMisfire					= false;
-	//
-	m_AmmoIDs.clear				();
 }
 
 CSE_ALifeItemWeapon::~CSE_ALifeItemWeapon	()
@@ -420,14 +418,6 @@ void CSE_ALifeItemWeapon::UPDATE_Read(NET_Packet	&tNetPacket)
 		u8 _data = tNetPacket.r_u8();
 		bMisfire = !!(_data & 0x1);
 	}
-	//
-	m_AmmoIDs.clear();
-	u8 AmmoCount = tNetPacket.r_u8();
-	for (u8 i = 0; i<AmmoCount; i++)
-	{
-		m_AmmoIDs.push_back(tNetPacket.r_u8());
-	}
-	//
 }
 
 void CSE_ALifeItemWeapon::UPDATE_Write(NET_Packet	&tNetPacket)
@@ -443,13 +433,6 @@ void CSE_ALifeItemWeapon::UPDATE_Write(NET_Packet	&tNetPacket)
 	tNetPacket.w_u8				(m_bZoom);
 	//
 	tNetPacket.w_u8				(bMisfire ? 1 : 0);
-	//
-	tNetPacket.w_u8				(u8(m_AmmoIDs.size()));
-	for (u32 i = 0; i<m_AmmoIDs.size(); i++)
-	{
-		tNetPacket.w_u8			(u8(m_AmmoIDs[i]));
-	}
-	//
 }
 
 void CSE_ALifeItemWeapon::STATE_Read(NET_Packet	&tNetPacket, u16 size)
@@ -605,6 +588,8 @@ CSE_ALifeItemWeaponMagazined::CSE_ALifeItemWeaponMagazined	(LPCSTR caSection) : 
 		m_u8CurFireMode = 0;
 	}
 	//
+	m_AmmoIDs.clear();
+	//
 	m_LastLoadedMagType = 0;
 	m_bIsMagazineAttached = true;
 }
@@ -619,6 +604,13 @@ void CSE_ALifeItemWeaponMagazined::UPDATE_Read		(NET_Packet& P)
 
 	m_u8CurFireMode = P.r_u8();
 	//
+	m_AmmoIDs.clear();
+	u8 AmmoCount = P.r_u8();
+	for (u8 i = 0; i<AmmoCount; i++)
+	{
+		m_AmmoIDs.push_back(P.r_u8());
+	}
+	//
 	m_LastLoadedMagType = P.r_u8();
 	m_bIsMagazineAttached	= !!(P.r_u8() & 0x1);
 }
@@ -627,6 +619,12 @@ void CSE_ALifeItemWeaponMagazined::UPDATE_Write	(NET_Packet& P)
 	inherited::UPDATE_Write(P);
 
 	P.w_u8(m_u8CurFireMode);	
+	//
+	P.w_u8(u8(m_AmmoIDs.size()));
+	for (u32 i = 0; i<m_AmmoIDs.size(); i++)
+	{
+		P.w_u8(u8(m_AmmoIDs[i]));
+	}
 	//
 	P.w_u8(m_LastLoadedMagType);
 	P.w_u8(m_bIsMagazineAttached ? 1 : 0);

--- a/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.h
+++ b/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.h
@@ -166,8 +166,6 @@ SERVER_ENTITY_DECLARE_BEGIN(CSE_ALifeItemWeapon,CSE_ALifeItem)
 	u32								m_ef_weapon_type;
 	//
 	bool							bMisfire;
-	//
-	xr_vector<u8>					m_AmmoIDs;
 
 									CSE_ALifeItemWeapon	(LPCSTR caSection);
 	virtual							~CSE_ALifeItemWeapon();
@@ -194,7 +192,7 @@ u8			m_LastLoadedMagType;
 //присоединён ли магазин
 bool		m_bIsMagazineAttached;
 //
-//xr_vector<u8> m_AmmoIDs;
+xr_vector<u8> m_AmmoIDs;
 //
 CSE_ALifeItemWeaponMagazined(LPCSTR caSection);
 virtual							~CSE_ALifeItemWeaponMagazined();

--- a/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.h
+++ b/trunk/xray/xr_3da/xrGame/xrServer_Objects_ALife_Items.h
@@ -141,9 +141,10 @@ SERVER_ENTITY_DECLARE_BEGIN(CSE_ALifeItemWeapon,CSE_ALifeItem)
 	//текущее состояние аддонов
 	enum EWeaponAddonState 
 	{
-		eWeaponAddonScope = 0x01,
-		eWeaponAddonGrenadeLauncher = 0x02,
-		eWeaponAddonSilencer = 0x04
+		eWeaponAddonScope			= (1 << 0),//0x01,
+		eWeaponAddonGrenadeLauncher = (1 << 1),//0x02,
+		eWeaponAddonSilencer		= (1 << 2),//0x04
+		eWeaponAddonMagazine		= (1 << 3) //флаг присоединённости отъёмного магазина
 	};
 
 	EWeaponAddonStatus				m_scope_status;
@@ -187,10 +188,8 @@ add_to_type_list(CSE_ALifeItemWeapon)
 
 SERVER_ENTITY_DECLARE_BEGIN(CSE_ALifeItemWeaponMagazined,CSE_ALifeItemWeapon)
 u8			m_u8CurFireMode;
-//последний заряженный тип магазина
-u8			m_LastLoadedMagType;
 //присоединён ли магазин
-bool		m_bIsMagazineAttached;
+//bool		m_bIsMagazineAttached;
 //
 xr_vector<u8> m_AmmoIDs;
 //


### PR DESCRIPTION
~m_LastLoadedMagType - не нужно сохранять/загружать, он вполне вычисляем

m_bIsMagazineAttached -> eWeaponAddonMagazine - состояние магазина хранится во флагах оружия (оружие заспавненное без патронов будет и без магазина).

~Загрузку разнородных патронов в магазине вернул в CWeaponMagazined и заменил на реализацию отсюда:
https://github.com/Charsi82/xray-1.5.10-2015-/commit/fb2fc90a97ff398b1effe3b944a1dc02b477e861